### PR TITLE
Fix logging when running under Gunicorn

### DIFF
--- a/Services/logging_config.py
+++ b/Services/logging_config.py
@@ -49,6 +49,11 @@ def setup_logging():
     # Get the root logger. All other loggers will inherit this configuration.
     root_logger = logging.getLogger()
 
+    # If the in-memory handler is already attached, avoid reconfiguring
+    for handler in root_logger.handlers:
+        if isinstance(handler, MemoryLogHandler):
+            return
+
     # Determine if running under Gunicorn by checking environment or process
     # Gunicorn sets the 'gunicorn' logger, which is a reliable check.
     is_gunicorn = "gunicorn" in os.environ.get("SERVER_SOFTWARE", "") or 'gunicorn.error' in logging.Logger.manager.loggerDict

--- a/working_app.py
+++ b/working_app.py
@@ -70,7 +70,9 @@ def handle_missing_api_key():
 def create_app():
     """Create and configure the Flask application."""
     global app, diagnostic_system
-    
+
+    # Ensure logging is configured in case Gunicorn reset it
+    Services.logging_config.setup_logging()
     # Create Flask app
     app = Flask(__name__, template_folder="templates", static_folder="static")
     


### PR DESCRIPTION
## Summary
- ensure memory log handler isn't removed when Gunicorn resets logging
- reconfigure logging during `create_app()` if necessary

## Testing
- `pytest -q` *(fails: FileNotFoundError: [Errno 2] No such file or directory: 'pdflatex')*

------
https://chatgpt.com/codex/tasks/task_e_6844aa7a248c8330aa4f4c2fba92eb00